### PR TITLE
January 26, 2021 meeting to dos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Resources for planning and hosting the Jupyter community calls. Community calls 
 
 # Next call: February 23 9am Pacific (Your [timezone](https://arewemeetingyet.com/Los%20Angeles/2021-02-23/09:00/Jupyter%20Community%20Call))
 
-[![Sign up to present](https://img.shields.io/badge/-Sign%20up%20to%20present-orange)](https://hackmd.io/l2yBruUATC6yH4F2gOUPgw)
+[![Sign up to present](https://img.shields.io/badge/-Sign%20up%20to%20present-orange)](https://hackmd.io/WZ9DCwZrQummM89-k3bC0A)
 
 [![Give feedback](https://img.shields.io/badge/-Give%20feedback-blue)](https://docs.google.com/forms/d/e/1FAIpQLScwfYswVhafS9PVIoQYepIExq3f-FP7EmsAFULCiTIgc7mRSA/viewform?usp=sf_link)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jupyter-communitycalls
 Resources for planning and hosting the Jupyter community calls. Community calls are a place to have fun and celebrate the cool things people do with/in the Jupyter ecosystem and are open to all.
 
-# Next call: January 26 9am Pacific (Your [timezone](https://arewemeetingyet.com/Los%20Angeles/2020-01-26/09:00/Jupyter%20Community%20Call))
+# Next call: February 23 9am Pacific (Your [timezone](https://arewemeetingyet.com/Los%20Angeles/2021-02-23/09:00/Jupyter%20Community%20Call))
 
 [![Sign up to present](https://img.shields.io/badge/-Sign%20up%20to%20present-orange)](https://hackmd.io/l2yBruUATC6yH4F2gOUPgw)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Resources for planning and hosting the Jupyter community calls. Community calls 
 
 [![Request to host](https://img.shields.io/badge/-Request%20to%20host-blueviolet)](https://gitter.im/isabela-pf)
 
-[![Join on Zoom](https://img.shields.io/badge/-Join%20on%20Zoom-brightgreen)](https://gitter.im/isabela-pf)
+[![Join on Zoom](https://img.shields.io/badge/-Join%20on%20Zoom-brightgreen)](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09)
 
 ## Index
 
@@ -23,7 +23,7 @@ Resources for planning and hosting the Jupyter community calls. Community calls 
 [Recorded calls playlist](https://www.youtube.com/playlist?list=PLUrHeD2K9Cmkoamm4NjLmvXC4Y6E1o8SP)
 
 ### For Participants
-[Sign up to present](https://hackmd.io/l2yBruUATC6yH4F2gOUPgw)
+[Sign up to present](https://hackmd.io/WZ9DCwZrQummM89-k3bC0A)
 
 [Give feedback](https://docs.google.com/forms/d/e/1FAIpQLScwfYswVhafS9PVIoQYepIExq3f-FP7EmsAFULCiTIgc7mRSA/viewform?usp=sf_link)
 


### PR DESCRIPTION
## January 26, 2021 meeting to dos

<!--Use this PR to change the readme with details for the call two months out. That way when this
to do list is complete and the PR is merged, the readme is ready to go with the correct date and 
links for the upcoming call.-->

Schedule call
- [x] Add to calendars
- [x] Make HackMD agenda/notes
- [x] Schedule host (let different people host)

Promote call/recruit presenters
- [x] Post on discourse 2 weeks before
- [x] Tweet 2 weeks before
- [x] Post on mailing list 2 weeks before
- [x] Post to jupyterhub/team-compass 2 weeks before
- [x] Post on discourse 1 week before
- [x] Post on mailing list 1 week before

Post-call
- [x] Download meeting recording
- [x] Upload meeting recording to youtube 
- [x] Submit PR for agenda/notes in docs
- [x] Add youtube and agenda/notes link to discourse page
- [x] Add youtube and agenda/notes link to jupyterhub/team-compass to follow up. Close next month.
- [x] Tweet youtube link
